### PR TITLE
Fix extracted_from_core? method

### DIFF
--- a/lib/foreman_puppet.rb
+++ b/lib/foreman_puppet.rb
@@ -1,9 +1,9 @@
 module ForemanPuppet
-  FOREMAN_EXTRACTION_VERSION = '2.5'.freeze
+  FOREMAN_EXTRACTION_VERSION = '2.6'.freeze
 
   def self.extracted_from_core?
     ENV['PUPPET_EXTRACTED'] == '1' ||
-      Gem::Dependency.new('', ">= #{FOREMAN_EXTRACTION_VERSION}").match?('', SETTINGS[:version])
+      Gem::Dependency.new('', ">= #{FOREMAN_EXTRACTION_VERSION}").match?('', SETTINGS[:version].notag)
   end
 end
 


### PR DESCRIPTION
`SETTINGS[:version]` returns `Foreman::Version` object, but we need a string to properly compare the version

```ruby
[37] pry(ForemanPuppet)> FOREMAN_EXTRACTION_VERSION
=> "2.5"
[38] pry(ForemanPuppet)> SETTINGS[:version]
=> #<Foreman::Version:0x00007faa16b13d58
 @build="0",
 @major="2",
 @minor="5",
 @notag="2.5.0",
 @short="2.5",
 @tag="develop",
 @version="2.5.0-develop">
[39] pry(ForemanPuppet)> Gem::Dependency.new('', ">= #{FOREMAN_EXTRACTION_VERSION}").match?('', SETTINGS[:version])
=> false
[40] pry(ForemanPuppet)> Gem::Dependency.new('', ">= #{FOREMAN_EXTRACTION_VERSION}").match?('', SETTINGS[:version].notag)
=> true
```