### PR TITLE
Patch param modules earlier

### DIFF
--- a/app/controllers/concerns/foreman_puppet/extensions/parameters_host.rb
+++ b/app/controllers/concerns/foreman_puppet/extensions/parameters_host.rb
@@ -34,16 +34,9 @@ module ForemanPuppet
         end
 
         def process_deprecated_environment_params!(params)
-          env_id = env_name = env = nil
-          if ForemanPuppet.extracted_from_core?
-            env_id = params.delete(:environment_id)
-            env_name = params.delete(:environment_name)
-            env = params.delete(:environment)
-          else
-            env_id = params[:environment_id]
-            env_name = params[:environment_name]
-            env = params[:environment]
-          end
+          env_id = params.delete(:environment_id)
+          env_name = params.delete(:environment_name)
+          env = params.delete(:environment)
 
           return unless env_id || env_name || env
           ::Foreman::Deprecation.api_deprecation_warning('param host[environment_*] has been deprecated in favor of host[puppet_attributes][environment_*]')

--- a/app/models/concerns/foreman_puppet/extensions/host.rb
+++ b/app/models/concerns/foreman_puppet/extensions/host.rb
@@ -61,6 +61,12 @@ module ForemanPuppet
       end
 
       module PrependedMethods
+        # TODO: we can drop this once extracted_from_core?
+        def validate_association_taxonomy(association_name)
+          return if association_name.to_sym == :environment
+          super
+        end
+
         def provisioning_template(opts = {})
           opts[:environment_id] ||= puppet&.environment_id
           super(opts)

--- a/lib/foreman_puppet/engine.rb
+++ b/lib/foreman_puppet/engine.rb
@@ -19,17 +19,19 @@ module ForemanPuppet
       end
     end
 
-    initializer 'foreman_ansible.configure_assets', group: :assets do
+    initializer 'foreman_puppet.configure_assets', group: :assets do
       SETTINGS[:foreman_puppet] = { assets: { precompile: ['foreman_puppet.scss'] } }
     end
 
-    # Include concerns in this config.to_prepare block
-    config.to_prepare do
+    initializer 'foreman_puppet.patch_parameters' do
       # Parameters should go ASAP as they need to be applied before they are included in core controller
       Foreman::Controller::Parameters::Host.include ForemanPuppet::Extensions::ParametersHost
       Foreman::Controller::Parameters::Hostgroup.include ForemanPuppet::Extensions::ParametersHostgroup
       Foreman::Controller::Parameters::TemplateCombination.include ForemanPuppet::Extensions::ParametersTemplateCombination
+    end
 
+    # Include concerns in this config.to_prepare block
+    config.to_prepare do
       # Facets extenstion is applied too early - before the Hostgroup is complete
       # We redefine thing, so we need to wait until complete definition of Hostgroup
       # thus separate patching instead of using facet patching

--- a/lib/foreman_puppet/register.rb
+++ b/lib/foreman_puppet/register.rb
@@ -170,7 +170,8 @@ Foreman::Plugin.register :foreman_puppet do
       # extend_model ForemanPuppet::Extensions::Host
       api_view list: 'foreman_puppet/api/v2/host_puppet_facets/base',
                single: 'foreman_puppet/api/v2/host_puppet_facets/host_single'
-      template_compatibility_properties :environment, :environment_id, :environment_name
+      template_compatibility_properties :environment, :environment_id, :environment_name,
+        :puppetclasses, :all_puppetclasses
       set_dependent_action :destroy
     end
     configure_hostgroup(ForemanPuppet::HostgroupPuppetFacet) do

--- a/test/factories/foreman_puppet_factories.rb
+++ b/test/factories/foreman_puppet_factories.rb
@@ -105,11 +105,14 @@ FactoryBot.define do
         evaluator.parameter_count.times do
           evaluator.environments.each do |env|
             FactoryBot.create :puppetclass_lookup_key, override: false, puppetclass: pc, environment: env
+            # for Host#managed validation, once extracted_from_core? we can remove
+            env.reload
           end
         end
       else
         evaluator.environments.each do |env|
           FactoryBot.create :environment_class, puppetclass: pc, environment: env unless env.nil?
+          env.reload
         end
       end
     end

--- a/test/models/foreman_puppet/host_test.rb
+++ b/test/models/foreman_puppet/host_test.rb
@@ -241,7 +241,7 @@ module ForemanPuppet
 
       host.puppet.environment = env_with_other_tax
       assert_not host.valid?
-      assert_match(/is not assigned/, host.errors[:environment_id].first)
+      assert_match(/is not assigned/, host.errors['puppet.environment_id'].first)
     end
 
     test 'when saving a host, require puppet environment if puppet master is set' do


### PR DESCRIPTION
We can end up with controllers getting required prior to_prepare and
that breaks patching the host_params.

Refs #132