### PR TITLE
Switch rubocop to 2.7

### DIFF
--- a/.github/workflows/ruby_tests.yml
+++ b/.github/workflows/ruby_tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - name: Run rubocop
         run: bundle exec rubocop -P --format github
@@ -66,7 +66,7 @@ jobs:
         run: bundle exec rake spec
   test_ruby:
     runs-on: ubuntu-latest
-    # needs: rubocop
+    needs: rubocop
     env:
       BUNDLE_WITHOUT: journald:development:console:libvirt
     services:
@@ -78,7 +78,7 @@ jobs:
       fail-fast: true
       matrix:
         foreman-core-branch: [2.5-stable, develop]
-        ruby-version: [2.5, 2.6]
+        ruby-version: [2.7]
         node-version: [12]
     steps:
       - run: sudo apt-get install build-essential libcurl4-openssl-dev zlib1g-dev libpq-dev

--- a/app/controllers/concerns/foreman_puppet/extensions/hostgroups_controller_extensions.rb
+++ b/app/controllers/concerns/foreman_puppet/extensions/hostgroups_controller_extensions.rb
@@ -42,7 +42,7 @@ module ForemanPuppet
         def puppetclass_parameters
           ::Taxonomy.as_taxonomy @organization, @location do
             render partial: 'foreman_puppet/puppetclasses/classes_parameters',
-                   locals: { obj: refresh_hostgroup }
+              locals: { obj: refresh_hostgroup }
           end
         end
 

--- a/app/controllers/concerns/foreman_puppet/extensions/hosts_controller_extensions.rb
+++ b/app/controllers/concerns/foreman_puppet/extensions/hosts_controller_extensions.rb
@@ -104,7 +104,7 @@ module ForemanPuppet
         rescue StandardError => e
           Foreman::Logging.exception("Failed to generate external nodes for #{@host}", e)
           render plain: _('Unable to generate output, Check log files'),
-                 status: :precondition_failed
+            status: :precondition_failed
         end
       end
       # rubocop:enable Naming/MethodName

--- a/app/controllers/concerns/foreman_puppet/parameters/puppetclass_lookup_key.rb
+++ b/app/controllers/concerns/foreman_puppet/parameters/puppetclass_lookup_key.rb
@@ -7,8 +7,8 @@ module ForemanPuppet
       def puppetclass_lookup_key_params_filter
         Foreman::ParameterFilter.new(ForemanPuppet::PuppetclassLookupKey).tap do |filter|
           filter.permit environments: [], environment_ids: [], environment_names: [],
-                        environment_classes: [], environment_classes_ids: [], environment_classes_names: [],
-                        param_classes: [], param_classes_ids: [], param_classes_names: []
+            environment_classes: [], environment_classes_ids: [], environment_classes_names: [],
+            param_classes: [], param_classes_ids: [], param_classes_names: []
           filter.permit_by_context :required, nested: true
           filter.permit_by_context :id, ui: false, api: false, nested: true
 

--- a/app/controllers/foreman_puppet/puppetclasses_controller.rb
+++ b/app/controllers/foreman_puppet/puppetclasses_controller.rb
@@ -70,8 +70,8 @@ module ForemanPuppet
     def parameters
       puppetclass = Puppetclass.find(params[:id])
       render partial: 'foreman_puppet/puppetclasses/class_parameters',
-             locals: { puppetclass: puppetclass,
-                       obj: find_host_or_hostgroup }
+        locals: { puppetclass: puppetclass,
+                  obj: find_host_or_hostgroup }
     end
 
     def resource_class

--- a/app/helpers/foreman_puppet/puppetclass_lookup_keys_helper.rb
+++ b/app/helpers/foreman_puppet/puppetclass_lookup_keys_helper.rb
@@ -2,8 +2,8 @@ module ForemanPuppet
   module PuppetclassLookupKeysHelper
     def puppetclass_lookup_keys_breadcrumbs
       breadcrumbs(resource_url: api_smart_class_parameters_path,
-                  name_field: 'parameter',
-                  switcher_item_url: '/puppetclass_lookup_keys/:id-:name/edit')
+        name_field: 'parameter',
+        switcher_item_url: '/puppetclass_lookup_keys/:id-:name/edit')
     end
 
     # ------ Host(group) Form Helpers -----

--- a/app/models/concerns/foreman_puppet/extensions/host.rb
+++ b/app/models/concerns/foreman_puppet/extensions/host.rb
@@ -18,11 +18,11 @@ module ForemanPuppet
 
         scoped_search relation: :environment, on: :name, complete_value: true, rename: :environment
         scoped_search relation: :puppetclasses, on: :name, complete_value: true, rename: :class, only_explicit: true, operators: ['= ', '~ '],
-                      ext_method: :search_by_deprecated_class
+          ext_method: :search_by_deprecated_class
         scoped_search relation: :puppetclasses, on: :name, complete_value: true, rename: :puppetclass, only_explicit: true, operators: ['= ', '~ '],
-                      ext_method: :search_by_puppetclass
+          ext_method: :search_by_puppetclass
         scoped_search relation: :config_groups, on: :name, complete_value: true, rename: :config_group, only_explicit: true, operators: ['= ', '~ '],
-                      ext_method: :search_by_config_group
+          ext_method: :search_by_config_group
       end
 
       class_methods do
@@ -81,9 +81,9 @@ module ForemanPuppet
           kinds = template_kinds(provisioning)
           kinds.map do |kind|
             ProvisioningTemplate.find_template({ kind: kind.name,
-                                                 operatingsystem_id: operatingsystem_id,
-                                                 hostgroup_id: hostgroup_id,
-                                                 environment_id: puppet&.environment_id })
+              operatingsystem_id: operatingsystem_id,
+              hostgroup_id: hostgroup_id,
+              environment_id: puppet&.environment_id })
           end.compact
         end
 

--- a/app/models/concerns/foreman_puppet/extensions/hostgroup.rb
+++ b/app/models/concerns/foreman_puppet/extensions/hostgroup.rb
@@ -17,11 +17,11 @@ module ForemanPuppet
         scoped_search relation: :environment, on: :name, complete_value: true, rename: :environment, only_explicit: true
         scoped_search relation: :puppetclasses, on: :name, complete_value: true, rename: :class, only_explicit: true, operators: ['= ', '~ ']
         scoped_search relation: :config_groups, on: :name,
-                      complete_value: true,
-                      rename: :config_group,
-                      only_explicit: true,
-                      operators: ['= ', '~ '],
-                      ext_method: :search_by_config_group
+          complete_value: true,
+          rename: :config_group,
+          only_explicit: true,
+          operators: ['= ', '~ '],
+          ext_method: :search_by_config_group
       end
 
       # Temporary, can be ordinary class_methods do, when removed from core

--- a/app/services/foreman_puppet/puppet_class_importer.rb
+++ b/app/services/foreman_puppet/puppet_class_importer.rb
@@ -298,7 +298,7 @@ module ForemanPuppet
       changed_params['new'].map do |param_name, value|
         param = find_or_create_puppet_class_param klass, param_name, value
         EnvironmentClass.find_or_create_by! puppetclass_id: klass.id, environment_id: env.id,
-                                            puppetclass_lookup_key_id: param.id
+          puppetclass_lookup_key_id: param.id
       end
     end
 
@@ -327,8 +327,8 @@ module ForemanPuppet
 
     def find_or_create_env(env)
       user_visible_environment(env) || Environment.create!(name: env,
-                                                           organizations: User.current.my_organizations,
-                                                           locations: User.current.my_locations)
+        organizations: User.current.my_organizations,
+        locations: User.current.my_locations)
     end
 
     def user_visible_environment(env)
@@ -339,7 +339,7 @@ module ForemanPuppet
     def find_or_create_puppet_class_param(klass, param_name, value)
       klass.class_params.where(key: param_name).first ||
         PuppetclassLookupKey.create!(key: param_name, default_value: value,
-                                     key_type: Foreman::ImporterPuppetclass.suggest_key_type(value))
+          key_type: Foreman::ImporterPuppetclass.suggest_key_type(value))
     end
 
     def find_or_create_puppetclass_for_env(klass_name, env)

--- a/lib/foreman_puppet/register.rb
+++ b/lib/foreman_puppet/register.rb
@@ -169,14 +169,14 @@ Foreman::Plugin.register :foreman_puppet do
     configure_host do
       # extend_model ForemanPuppet::Extensions::Host
       api_view list: 'foreman_puppet/api/v2/host_puppet_facets/base',
-               single: 'foreman_puppet/api/v2/host_puppet_facets/host_single'
+        single: 'foreman_puppet/api/v2/host_puppet_facets/host_single'
       template_compatibility_properties :environment, :environment_id, :environment_name,
         :puppetclasses, :all_puppetclasses
       set_dependent_action :destroy
     end
     configure_hostgroup(ForemanPuppet::HostgroupPuppetFacet) do
       api_view list: 'foreman_puppet/api/v2/hostgroup_puppet_facets/base',
-               single: 'foreman_puppet/api/v2/hostgroup_puppet_facets/hostgroup_single'
+        single: 'foreman_puppet/api/v2/hostgroup_puppet_facets/hostgroup_single'
       template_compatibility_properties :environment, :environment_id, :environment_name
       set_dependent_action :destroy
     end

--- a/test/models/foreman_puppet/provisioning_template_test.rb
+++ b/test/models/foreman_puppet/provisioning_template_test.rb
@@ -77,47 +77,47 @@ module ForemanPuppet
       test 'find_template finds a matching template with hg and env' do
         assert_equal @ct1.name,
           ProvisioningTemplate.find_template({ kind: @tk.name,
-                                               operatingsystem_id: @os1.id,
-                                               hostgroup_id: @hg1.id,
-                                               environment_id: @ev1.id }).name
+            operatingsystem_id: @os1.id,
+            hostgroup_id: @hg1.id,
+            environment_id: @ev1.id }).name
       end
 
       test 'find_template finds a matching template with hg only' do
         assert_equal @ct2.name,
           ProvisioningTemplate.find_template({ kind: @tk.name,
-                                               operatingsystem_id: @os1.id,
-                                               hostgroup_id: @hg1.id }).name
+            operatingsystem_id: @os1.id,
+            hostgroup_id: @hg1.id }).name
       end
 
       test 'find_template finds a matching template with hg and mismatched env' do
         assert_equal @ct2.name,
           ProvisioningTemplate.find_template({ kind: @tk.name,
-                                               operatingsystem_id: @os1.id,
-                                               hostgroup_id: @hg1.id,
-                                               environment_id: @ev3.id }).name
+            operatingsystem_id: @os1.id,
+            hostgroup_id: @hg1.id,
+            environment_id: @ev3.id }).name
       end
 
       test 'find_template finds a matching template with env only' do
         assert_equal @ct3.name,
           ProvisioningTemplate.find_template({ kind: @tk.name,
-                                               operatingsystem_id: @os1.id,
-                                               environment_id: @ev1.id }).name
+            operatingsystem_id: @os1.id,
+            environment_id: @ev1.id }).name
       end
 
       test 'find_template finds a matching template with env and mismatched hg' do
         assert_equal @ct3.name,
           ProvisioningTemplate.find_template({ kind: @tk.name,
-                                               operatingsystem_id: @os1.id,
-                                               hostgroup_id: @hg3.id,
-                                               environment_id: @ev1.id }).name
+            operatingsystem_id: @os1.id,
+            hostgroup_id: @hg3.id,
+            environment_id: @ev1.id }).name
       end
 
       test 'find_template finds the default template when hg and env do not match' do
         assert_equal @ctd.name,
           ProvisioningTemplate.find_template({ kind: @tk.name,
-                                               operatingsystem_id: @os1.id,
-                                               hostgroup_id: @hg3.id,
-                                               environment_id: @ev3.id }).name
+            operatingsystem_id: @os1.id,
+            hostgroup_id: @hg3.id,
+            environment_id: @ev3.id }).name
       end
     end
   end

--- a/test/services/foreman_puppet/host_info_providers/puppet_info_test.rb
+++ b/test/services/foreman_puppet/host_info_providers/puppet_info_test.rb
@@ -37,9 +37,9 @@ module ForemanPuppet
 
       value = as_admin do
         LookupValue.create! lookup_key_id: puppetclass_lookup_key.id,
-                            match: "organization=#{taxonomies(:organization1)},location=#{taxonomies(:location1)}",
-                            value: 'test',
-                            omit: false
+          match: "organization=#{taxonomies(:organization1)},location=#{taxonomies(:location1)}",
+          value: 'test',
+          omit: false
       end
       enc = HostInfoProviders::PuppetInfo.new(@host).puppetclass_parameters
 
@@ -78,19 +78,17 @@ module ForemanPuppet
       host = FactoryBot.build_stubbed(:host, :with_puppet_enc, environment: environment, puppetclasses: [puppetclass])
       Classification::MatchesGenerator.any_instance.expects(:attr_to_value).with('comment').returns('override')
 
-      assert_equal(
-        {
-          lkey.id => {
-            lkey.key => {
-              value: 'overridden value',
-              element: 'comment',
-              element_name: 'override',
-              managed: false,
-            },
+      expected = {
+        lkey.id => {
+          lkey.key => {
+            value: 'overridden value',
+            element: 'comment',
+            element_name: 'override',
+            managed: false,
           },
         },
-        Classification::ValuesHashQuery.values_hash(host, LookupKey.where(id: [lkey])).raw
-      )
+      }
+      assert_equal(expected, Classification::ValuesHashQuery.values_hash(host, LookupKey.where(id: [lkey])).raw)
 
       Classification::MatchesGenerator.any_instance.unstub(:attr_to_value)
     end
@@ -108,9 +106,9 @@ module ForemanPuppet
         puppetclass: puppetclass, path: "location\ncomment")
       as_admin do
         LookupValue.create! lookup_key_id: lkey.id,
-                            match: "location=#{taxonomies(:location1)}",
-                            value: 'test',
-                            omit: true
+          match: "location=#{taxonomies(:location1)}",
+          value: 'test',
+          omit: true
       end
 
       enc = HostInfoProviders::PuppetInfo.new(@host).puppetclass_parameters
@@ -124,9 +122,9 @@ module ForemanPuppet
                                                                         path: "location\ncomment")
       lvalue = as_admin do
         LookupValue.create! lookup_key_id: lkey.id,
-                            match: "location=#{taxonomies(:location1)}",
-                            value: 'test',
-                            omit: false
+          match: "location=#{taxonomies(:location1)}",
+          value: 'test',
+          omit: false
       end
 
       enc = HostInfoProviders::PuppetInfo.new(@host).puppetclass_parameters
@@ -142,22 +140,22 @@ module ForemanPuppet
 
       as_admin do
         LookupValue.create! lookup_key_id: key.id,
-                            match: "location=#{taxonomies(:location1)}",
-                            value: { example: { a: 'test' } },
-                            omit: true
+          match: "location=#{taxonomies(:location1)}",
+          value: { example: { a: 'test' } },
+          omit: true
       end
       as_admin do
         LookupValue.create! lookup_key_id: key.id,
-                            match: "organization=#{taxonomies(:organization1)}",
-                            value: { example: { b: 'test2' } },
-                            omit: true
+          match: "organization=#{taxonomies(:organization1)}",
+          value: { example: { b: 'test2' } },
+          omit: true
       end
 
       as_admin do
         LookupValue.create! lookup_key_id: key.id,
-                            match: "os=#{operatingsystems(:redhat)}",
-                            value: { example: { a: 'test3' } },
-                            omit: true
+          match: "os=#{operatingsystems(:redhat)}",
+          value: { example: { a: 'test3' } },
+          omit: true
       end
 
       enc = HostInfoProviders::PuppetInfo.new(@host).puppetclass_parameters
@@ -184,13 +182,13 @@ module ForemanPuppet
 
       as_admin do
         LookupValue.create! lookup_key_id: key.id,
-                            match: "hostgroup=#{parent_hostgroup}",
-                            value: ['parent'],
-                            omit: false
+          match: "hostgroup=#{parent_hostgroup}",
+          value: ['parent'],
+          omit: false
         LookupValue.create! lookup_key_id: key.id,
-                            match: "organization=#{taxonomies(:organization1)}",
-                            value: ['org'],
-                            omit: false
+          match: "organization=#{taxonomies(:organization1)}",
+          value: ['org'],
+          omit: false
       end
 
       enc = HostInfoProviders::PuppetInfo.new(host).puppetclass_parameters
@@ -218,13 +216,13 @@ module ForemanPuppet
 
       as_admin do
         LookupValue.create! lookup_key_id: key.id,
-                            match: "organization=#{parent_org}",
-                            value: ['parent'],
-                            omit: false
+          match: "organization=#{parent_org}",
+          value: ['parent'],
+          omit: false
         LookupValue.create! lookup_key_id: key.id,
-                            match: "location=#{taxonomies(:location1)}",
-                            value: ['loc'],
-                            omit: false
+          match: "location=#{taxonomies(:location1)}",
+          value: ['loc'],
+          omit: false
       end
 
       enc = HostInfoProviders::PuppetInfo.new(host).puppetclass_parameters
@@ -252,13 +250,13 @@ module ForemanPuppet
 
       as_admin do
         LookupValue.create! lookup_key_id: key.id,
-                            match: "location=#{parent_loc}",
-                            value: ['parent'],
-                            omit: false
+          match: "location=#{parent_loc}",
+          value: ['parent'],
+          omit: false
         LookupValue.create! lookup_key_id: key.id,
-                            match: "organization=#{taxonomies(:organization1)}",
-                            value: ['org'],
-                            omit: false
+          match: "organization=#{taxonomies(:organization1)}",
+          value: ['org'],
+          omit: false
       end
 
       enc = HostInfoProviders::PuppetInfo.new(host).puppetclass_parameters
@@ -285,17 +283,17 @@ module ForemanPuppet
 
       as_admin do
         LookupValue.create! lookup_key_id: key.id,
-                            match: "hostgroup=#{parent_hostgroup}",
-                            value: ['parent'],
-                            omit: false
+          match: "hostgroup=#{parent_hostgroup}",
+          value: ['parent'],
+          omit: false
         LookupValue.create! lookup_key_id: key.id,
-                            match: "hostgroup=#{child_hostgroup}",
-                            value: ['child'],
-                            omit: false
+          match: "hostgroup=#{child_hostgroup}",
+          value: ['child'],
+          omit: false
         LookupValue.create! lookup_key_id: key.id,
-                            match: "organization=#{taxonomies(:organization1)}",
-                            value: ['org'],
-                            omit: false
+          match: "organization=#{taxonomies(:organization1)}",
+          value: ['org'],
+          omit: false
       end
 
       enc = HostInfoProviders::PuppetInfo.new(host).puppetclass_parameters
@@ -323,17 +321,17 @@ module ForemanPuppet
 
       as_admin do
         LookupValue.create! lookup_key_id: key.id,
-                            match: "organization=#{parent_org}",
-                            value: ['parent'],
-                            omit: false
+          match: "organization=#{parent_org}",
+          value: ['parent'],
+          omit: false
         LookupValue.create! lookup_key_id: key.id,
-                            match: "organization=#{child_org}",
-                            value: ['child'],
-                            omit: false
+          match: "organization=#{child_org}",
+          value: ['child'],
+          omit: false
         LookupValue.create! lookup_key_id: key.id,
-                            match: "location=#{taxonomies(:location1)}",
-                            value: ['loc'],
-                            omit: false
+          match: "location=#{taxonomies(:location1)}",
+          value: ['loc'],
+          omit: false
       end
 
       enc = HostInfoProviders::PuppetInfo.new(host).puppetclass_parameters
@@ -361,17 +359,17 @@ module ForemanPuppet
 
       as_admin do
         LookupValue.create! lookup_key_id: key.id,
-                            match: "location=#{parent_loc}",
-                            value: ['parent'],
-                            omit: false
+          match: "location=#{parent_loc}",
+          value: ['parent'],
+          omit: false
         LookupValue.create! lookup_key_id: key.id,
-                            match: "location=#{child_loc}",
-                            value: ['child'],
-                            omit: false
+          match: "location=#{child_loc}",
+          value: ['child'],
+          omit: false
         LookupValue.create! lookup_key_id: key.id,
-                            match: "organization=#{taxonomies(:organization1)}",
-                            value: ['org'],
-                            omit: false
+          match: "organization=#{taxonomies(:organization1)}",
+          value: ['org'],
+          omit: false
       end
 
       enc = HostInfoProviders::PuppetInfo.new(host).puppetclass_parameters
@@ -398,17 +396,17 @@ module ForemanPuppet
 
       value2 = as_admin do
         LookupValue.create! lookup_key_id: key.id,
-                            match: "hostgroup=#{parent_hostgroup}",
-                            value: 'parent',
-                            omit: false
+          match: "hostgroup=#{parent_hostgroup}",
+          value: 'parent',
+          omit: false
         LookupValue.create! lookup_key_id: key.id,
-                            match: "hostgroup=#{child_hostgroup}",
-                            value: 'child',
-                            omit: false
+          match: "hostgroup=#{child_hostgroup}",
+          value: 'child',
+          omit: false
         LookupValue.create! lookup_key_id: key.id,
-                            match: "organization=#{taxonomies(:organization1)}",
-                            value: 'org',
-                            omit: false
+          match: "organization=#{taxonomies(:organization1)}",
+          value: 'org',
+          omit: false
       end
 
       enc = HostInfoProviders::PuppetInfo.new(host).puppetclass_parameters
@@ -434,17 +432,17 @@ module ForemanPuppet
 
       value2 = as_admin do
         LookupValue.create! lookup_key_id: key.id,
-                            match: "organization=#{parent_org}",
-                            value: 'parent',
-                            omit: false
+          match: "organization=#{parent_org}",
+          value: 'parent',
+          omit: false
         LookupValue.create! lookup_key_id: key.id,
-                            match: "organization=#{child_org}",
-                            value: 'child',
-                            omit: false
+          match: "organization=#{child_org}",
+          value: 'child',
+          omit: false
         LookupValue.create! lookup_key_id: key.id,
-                            match: "location=#{taxonomies(:location1)}",
-                            value: 'loc',
-                            omit: false
+          match: "location=#{taxonomies(:location1)}",
+          value: 'loc',
+          omit: false
       end
 
       enc = HostInfoProviders::PuppetInfo.new(host).puppetclass_parameters
@@ -470,17 +468,17 @@ module ForemanPuppet
 
       value2 = as_admin do
         LookupValue.create! lookup_key_id: key.id,
-                            match: "location=#{parent_loc}",
-                            value: 'parent',
-                            omit: false
+          match: "location=#{parent_loc}",
+          value: 'parent',
+          omit: false
         LookupValue.create! lookup_key_id: key.id,
-                            match: "location=#{child_loc}",
-                            value: 'child',
-                            omit: false
+          match: "location=#{child_loc}",
+          value: 'child',
+          omit: false
         LookupValue.create! lookup_key_id: key.id,
-                            match: "organization=#{taxonomies(:organization1)}",
-                            value: 'org',
-                            omit: false
+          match: "organization=#{taxonomies(:organization1)}",
+          value: 'org',
+          omit: false
       end
 
       enc = HostInfoProviders::PuppetInfo.new(host).puppetclass_parameters
@@ -506,17 +504,17 @@ module ForemanPuppet
 
       value2 = as_admin do
         LookupValue.create! lookup_key_id: key.id,
-                            match: "hostgroup=#{parent_hostgroup}",
-                            value: 'parent',
-                            omit: false
+          match: "hostgroup=#{parent_hostgroup}",
+          value: 'parent',
+          omit: false
         LookupValue.create! lookup_key_id: key.id,
-                            match: "location=#{taxonomies(:location1)}",
-                            value: 'loc',
-                            omit: true
+          match: "location=#{taxonomies(:location1)}",
+          value: 'loc',
+          omit: true
         LookupValue.create! lookup_key_id: key.id,
-                            match: "hostgroup=#{child_hostgroup}",
-                            value: 'child',
-                            omit: false
+          match: "hostgroup=#{child_hostgroup}",
+          value: 'child',
+          omit: false
       end
 
       enc = HostInfoProviders::PuppetInfo.new(host).puppetclass_parameters
@@ -544,17 +542,17 @@ module ForemanPuppet
 
       value2 = as_admin do
         LookupValue.create! lookup_key_id: key.id,
-                            match: "organization=#{parent_org}",
-                            value: 'parent',
-                            omit: false
+          match: "organization=#{parent_org}",
+          value: 'parent',
+          omit: false
         LookupValue.create! lookup_key_id: key.id,
-                            match: "location=#{taxonomies(:location1)}",
-                            value: 'loc',
-                            omit: true
+          match: "location=#{taxonomies(:location1)}",
+          value: 'loc',
+          omit: true
         LookupValue.create! lookup_key_id: key.id,
-                            match: "organization=#{child_org}",
-                            value: 'child',
-                            omit: false
+          match: "organization=#{child_org}",
+          value: 'child',
+          omit: false
       end
 
       enc = HostInfoProviders::PuppetInfo.new(host).puppetclass_parameters
@@ -582,17 +580,17 @@ module ForemanPuppet
 
       value2 = as_admin do
         LookupValue.create! lookup_key_id: key.id,
-                            match: "location=#{parent_loc}",
-                            value: 'parent',
-                            omit: false
+          match: "location=#{parent_loc}",
+          value: 'parent',
+          omit: false
         LookupValue.create! lookup_key_id: key.id,
-                            match: "organization=#{taxonomies(:organization1)}",
-                            value: 'org',
-                            omit: true
+          match: "organization=#{taxonomies(:organization1)}",
+          value: 'org',
+          omit: true
         LookupValue.create! lookup_key_id: key.id,
-                            match: "location=#{child_loc}",
-                            value: 'child',
-                            omit: false
+          match: "location=#{child_loc}",
+          value: 'child',
+          omit: false
       end
 
       enc = HostInfoProviders::PuppetInfo.new(host).puppetclass_parameters
@@ -608,13 +606,13 @@ module ForemanPuppet
 
       value2 = as_admin do
         LookupValue.create! lookup_key_id: key.id,
-                            match: "location=#{taxonomies(:location1)}",
-                            value: 'test_incorrect',
-                            omit: false
+          match: "location=#{taxonomies(:location1)}",
+          value: 'test_incorrect',
+          omit: false
         LookupValue.create! lookup_key_id: key.id,
-                            match: "organization=#{taxonomies(:organization1)},location=#{taxonomies(:location1)}",
-                            value: 'test_correct',
-                            omit: false
+          match: "organization=#{taxonomies(:organization1)},location=#{taxonomies(:location1)}",
+          value: 'test_correct',
+          omit: false
       end
       enc = HostInfoProviders::PuppetInfo.new(@host).puppetclass_parameters
       key.reload
@@ -630,15 +628,15 @@ module ForemanPuppet
 
       value = as_admin do
         LookupValue.create! lookup_key_id: key.id,
-                            match: "organization=#{taxonomies(:organization1)},location=#{taxonomies(:location1)}",
-                            value: 'test_correct',
-                            omit: false
+          match: "organization=#{taxonomies(:organization1)},location=#{taxonomies(:location1)}",
+          value: 'test_correct',
+          omit: false
       end
       as_admin do
         LookupValue.create! lookup_key_id: key.id,
-                            match: "organization=#{taxonomies(:organization1)}",
-                            value: 'test_incorrect',
-                            omit: false
+          match: "organization=#{taxonomies(:organization1)}",
+          value: 'test_incorrect',
+          omit: false
       end
       enc = HostInfoProviders::PuppetInfo.new(@host).puppetclass_parameters
 
@@ -662,22 +660,22 @@ module ForemanPuppet
 
       as_admin do
         LookupValue.create! lookup_key_id: key.id,
-                            match: "hostgroup=#{parent_hostgroup},organization=#{taxonomies(:organization1)}",
-                            value: 'parent',
-                            omit: false
+          match: "hostgroup=#{parent_hostgroup},organization=#{taxonomies(:organization1)}",
+          value: 'parent',
+          omit: false
       end
       value2 = as_admin do
         LookupValue.create! lookup_key_id: key.id,
-                            match: "hostgroup=#{child_hostgroup},organization=#{taxonomies(:organization1)}",
-                            value: 'child',
-                            omit: false
+          match: "hostgroup=#{child_hostgroup},organization=#{taxonomies(:organization1)}",
+          value: 'child',
+          omit: false
       end
 
       as_admin do
         LookupValue.create! lookup_key_id: key.id,
-                            match: "location=#{taxonomies(:location1)}",
-                            value: 'loc',
-                            omit: false
+          match: "location=#{taxonomies(:location1)}",
+          value: 'loc',
+          omit: false
       end
 
       enc = HostInfoProviders::PuppetInfo.new(host).puppetclass_parameters
@@ -694,21 +692,21 @@ module ForemanPuppet
 
       as_admin do
         LookupValue.create! lookup_key_id: key.id,
-                            match: "location=#{taxonomies(:location1)}",
-                            value: '<%= [2,3] %>',
-                            omit: false
+          match: "location=#{taxonomies(:location1)}",
+          value: '<%= [2,3] %>',
+          omit: false
       end
       as_admin do
         LookupValue.create! lookup_key_id: key.id,
-                            match: "organization=#{taxonomies(:organization1)}",
-                            value: '<%= [3,4] %>',
-                            omit: false
+          match: "organization=#{taxonomies(:organization1)}",
+          value: '<%= [3,4] %>',
+          omit: false
       end
       as_admin do
         LookupValue.create! lookup_key_id: key.id,
-                            match: "os=#{operatingsystems(:redhat)}",
-                            value: '<%= [4,5] %>',
-                            omit: false
+          match: "os=#{operatingsystems(:redhat)}",
+          value: '<%= [4,5] %>',
+          omit: false
       end
 
       key.reload
@@ -764,9 +762,9 @@ module ForemanPuppet
 
       as_admin do
         LookupValue.create! lookup_key_id: key.id,
-                            match: "location=#{taxonomies(:location1)}",
-                            value: '<%= "c" %>',
-                            omit: false
+          match: "location=#{taxonomies(:location1)}",
+          value: '<%= "c" %>',
+          omit: false
       end
 
       key.reload


### PR DESCRIPTION
It seems rubocop was ignoring the ArgumentAlignment rule up until now.