### PR TITLE
Fix broken README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Gem Version](https://img.shields.io/gem/v/foreman_puppet.svg)](https://rubygems.org/gems/foreman_puppet)
 [![GPL License](https://img.shields.io/github/license/theforeman/foreman_puppet.svg)](https://github.com/theforeman/foreman_puppet/blob/master/LICENSE)
 
-This plugin adds Puppet External node classification functionality to [Foreman](theforeman.org).
+This plugin adds Puppet External node classification functionality to [Foreman](https://theforeman.org).
 
 * Website: [theforeman.org](http://theforeman.org)
 * Support: [Foreman support](http://theforeman.org/support.html)
@@ -32,7 +32,7 @@ Some features will remain in core:
 ## Compatibility
 
 Foreman 3.0 will be the first release where the Puppet functionality is mostly extracted.
-Therefore, this plugin is only required for 3.0 and onwards.  
+Therefore, this plugin is only required for 3.0 and onwards.
 You can install it on Foreman 2.5 to prepare for the Foreman update.
 
 |Foreman version|Plugin version|Notes                                     |

--- a/foreman_puppet.gemspec
+++ b/foreman_puppet.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.license     = 'GPL-3.0'
   s.authors     = IO.readlines(File.expand_path('AUTHORS', __dir__), encoding: 'utf-8').map(&:strip)
   s.email       = ['foreman-dev@googlegroups.com']
-  s.homepage    = 'https://theforeman.org'
+  s.homepage    = 'https://github.com/theforeman/foreman_puppet'
   s.summary     = 'Adds puppet ENC features'
   # also update locale/gemspec.rb
   s.description = 'Allow assigning Puppet environmets and classes to the Foreman Hosts.'


### PR DESCRIPTION
The README link is currently broken.

Suggestion for gemspec: The link in the `Foreman plugin list` on the `About` page is pointing at the Foreman main page, but there are many plugins that also point at their github page. 