### PR TITLE
Remove usage of core classes

### DIFF
--- a/app/controllers/concerns/foreman_puppet/extensions/api_template_combinations_controller.rb
+++ b/app/controllers/concerns/foreman_puppet/extensions/api_template_combinations_controller.rb
@@ -6,7 +6,7 @@ module ForemanPuppet
       included do
         if ForemanPuppet.extracted_from_core?
           apipie_update_methods(%i[index create show update]) do
-            param :environment_id, String, desc: N_('ID of environment')
+            param :environment_id, nil, desc: N_('ID of environment')
           end
         end
 

--- a/app/models/concerns/foreman_puppet/extensions/host.rb
+++ b/app/models/concerns/foreman_puppet/extensions/host.rb
@@ -6,7 +6,9 @@ module ForemanPuppet
       included do
         prepend PrependedMethods
 
-        unless ForemanPuppet.extracted_from_core?
+        if ForemanPuppet.extracted_from_core?
+          has_one :environment, through: :puppet, class_name: 'ForemanPuppet::Environment'
+        else
           env_assoc = reflect_on_association(:environment)
           env_assoc&.instance_variable_set(:@class_name, 'ForemanPuppet::Environment')
 

--- a/app/models/concerns/foreman_puppet/extensions/hostgroup.rb
+++ b/app/models/concerns/foreman_puppet/extensions/hostgroup.rb
@@ -8,8 +8,12 @@ module ForemanPuppet
           prepend PatchedClassMethods
         end
 
-        env_assoc = reflect_on_association(:environment)
-        env_assoc.instance_variable_set(:@class_name, 'ForemanPuppet::Environment')
+        if ForemanPuppet.extracted_from_core?
+          has_one :environment, through: :puppet, class_name: 'ForemanPuppet::Environment'
+        else
+          env_assoc = reflect_on_association(:environment)
+          env_assoc&.instance_variable_set(:@class_name, 'ForemanPuppet::Environment')
+        end
 
         include_in_clone puppet: %i[host_config_groups config_groups hostgroup_classes]
 

--- a/app/models/concerns/foreman_puppet/extensions/operatingsystem.rb
+++ b/app/models/concerns/foreman_puppet/extensions/operatingsystem.rb
@@ -4,7 +4,7 @@ module ForemanPuppet
       extend ActiveSupport::Concern
 
       included do
-        has_and_belongs_to_many :puppetclasses
+        has_and_belongs_to_many :puppetclasses, class_name: 'ForemanPuppet::Puppetclass'
       end
     end
   end

--- a/app/models/concerns/foreman_puppet/extensions/taxonomy.rb
+++ b/app/models/concerns/foreman_puppet/extensions/taxonomy.rb
@@ -6,7 +6,7 @@ module ForemanPuppet
       included do
         has_many :environments, through: :taxable_taxonomies, source: :taxable, source_type: 'ForemanPuppet::Environment'
 
-        has_many :puppetclasses, through: :environments
+        has_many :puppetclasses, through: :environments, class_name: 'ForemanPuppet::Puppetclass'
       end
 
       def dup

--- a/db/migrate/20200803113903_migrate_host_type_in_host_config_groups.foreman_puppet.rb
+++ b/db/migrate/20200803113903_migrate_host_type_in_host_config_groups.foreman_puppet.rb
@@ -1,29 +1,35 @@
 class MigrateHostTypeInHostConfigGroups < ActiveRecord::Migration[6.0]
+  class FakeHostConfigGroup < ::ApplicationRecord
+    self.table_name = 'host_config_groups'
+  end
+
   def up
-    host_config_group_ids = HostConfigGroup.where(host_type: %w[Host::Base Host::Managed]).pluck(:host_id).uniq
+    host_config_group_ids = FakeHostConfigGroup.where(host_type: %w[Host::Base Host::Managed]).pluck(:host_id).uniq
     host_config_group_ids.each do |host_id|
       host_facet_id = ForemanPuppet::HostPuppetFacet.where(host_id: host_id).pick(:id)
-      HostConfigGroup.where(host_type: %w[Host::Base Host::Managed], host_id: host_id).update_all(host_type: 'ForemanPuppet::HostPuppetFacet', host_id: host_facet_id)
+      FakeHostConfigGroup.where(host_type: %w[Host::Base Host::Managed], host_id: host_id)
+                         .update_all(host_type: 'ForemanPuppet::HostPuppetFacet', host_id: host_facet_id)
     end
-    hostgroup_config_group_ids = HostConfigGroup.where(host_type: 'Hostgroup').pluck(:host_id).uniq
+    hostgroup_config_group_ids = FakeHostConfigGroup.where(host_type: 'Hostgroup').pluck(:host_id).uniq
     hostgroup_config_group_ids.each do |hostgroup_id|
       hostgroup_facet_id = ForemanPuppet::HostgroupPuppetFacet.where(hostgroup_id: hostgroup_id).pick(:id)
-      HostConfigGroup.where(host_type: 'Hostgroup', host_id: hostgroup_id).update_all(host_type: 'ForemanPuppet::HostgroupPuppetFacet', host_id: hostgroup_facet_id)
+      FakeHostConfigGroup.where(host_type: 'Hostgroup', host_id: hostgroup_id)
+                         .update_all(host_type: 'ForemanPuppet::HostgroupPuppetFacet', host_id: hostgroup_facet_id)
     end
   end
 
   def down
-    host_config_group_ids = HostConfigGroup.where(host_type: 'ForemanPuppet::HostPuppetFacet').pluck(:host_id).uniq
+    host_config_group_ids = FakeHostConfigGroup.where(host_type: 'ForemanPuppet::HostPuppetFacet').pluck(:host_id).uniq
     host_facet_ids = ForemanPuppet::HostPuppetFacet.where(id: host_config_group_ids).pluck(:id, :host_id).to_h
     host_config_group_ids.each do |host_puppet_facet_id|
-      HostConfigGroup.where(host_type: 'ForemanPuppet::HostPuppetFacet', host_id: host_puppet_facet_id)
-                     .update_all(host_type: 'Host::Managed', host_id: host_facet_ids[host_puppet_facet_id])
+      FakeHostConfigGroup.where(host_type: 'ForemanPuppet::HostPuppetFacet', host_id: host_puppet_facet_id)
+                         .update_all(host_type: 'Host::Managed', host_id: host_facet_ids[host_puppet_facet_id])
     end
-    hostgroup_config_group_ids = HostConfigGroup.where(host_type: 'ForemanPuppet::HostgroupPuppetFacet').pluck(:host_id).uniq
+    hostgroup_config_group_ids = FakeHostConfigGroup.where(host_type: 'ForemanPuppet::HostgroupPuppetFacet').pluck(:host_id).uniq
     hostgroup_facet_ids = ForemanPuppet::HostgroupPuppetFacet.where(id: hostgroup_config_group_ids).pluck(:id, :hostgroup_id).to_h
     hostgroup_config_group_ids.each do |hostgroup_facet_id|
-      HostConfigGroup.where(host_type: 'ForemanPuppet::HostgroupPuppetFacet', host_id: hostgroup_facet_id)
-                     .update_all(host_type: 'Hostgroup', host_id: hostgroup_facet_ids[hostgroup_facet_id])
+      FakeHostConfigGroup.where(host_type: 'ForemanPuppet::HostgroupPuppetFacet', host_id: hostgroup_facet_id)
+                         .update_all(host_type: 'Hostgroup', host_id: hostgroup_facet_ids[hostgroup_facet_id])
     end
   end
 end


### PR DESCRIPTION
We are still using core classes at some places, we need to fix that in
order for the plugin to work with Foreman 3.0, where the classes will be
missing.