### PR TITLE
Fix smart proxy import

### DIFF
--- a/config/api_routes.rb
+++ b/config/api_routes.rb
@@ -2,7 +2,7 @@ ForemanPuppet::Engine.routes.draw do
   namespace :api, defaults: { format: 'json' } do
     scope '(:apiv)', module: :v2, defaults: { apiv: 'v2' }, apiv: /v1|v2/, constraints: ApiConstraints.new(version: 2, default: true) do
       constraints(id: %r{[^/]+}) do
-        resources :puppet_smart_proxies, only: [] do
+        resources :smart_proxies, only: [] do
           post :import_puppetclasses, on: :member, controller: 'environments'
 
           resources :environments, only: [] do
@@ -31,6 +31,9 @@ ForemanPuppet::Engine.routes.draw do
         resources :environments, except: %i[new edit] do
           resources :locations, only: %i[index show], controller: '/api/v2/locations'
           resources :organizations, only: %i[index show], controller: '/api/v2/organizations'
+          resources :smart_proxies, only: [] do
+            post :import_puppetclasses, on: :member, controller: 'environments'
+          end
           resources :smart_class_parameters, except: %i[new edit create] do
             resources :override_values, except: %i[new edit]
           end


### PR DESCRIPTION
POST /foreman_puppet/api/smart_proxies/:id/import_puppetclasses
POST /foreman_puppet/api/smart_proxies/:smart_proxy_id/environments/:id/import_puppetclasses 
POST /foreman_puppet/api/environments/:environment_id/smart_proxies/:id/import_puppetclasses

were not working although they appear in the apidoc