### PR TITLE
Remove wrong deprecation warning for smart proxy import-classes API call

### DIFF
--- a/app/controllers/foreman_puppet/api/v2/puppet_base_controller.rb
+++ b/app/controllers/foreman_puppet/api/v2/puppet_base_controller.rb
@@ -11,7 +11,7 @@ module ForemanPuppet
         protected
 
         def show_deprecation_for_core_routes
-          return if request.path.starts_with?('/foreman_puppet')
+          return if request.path.starts_with?('/foreman_puppet') || request.path.starts_with?('/api/smart_proxies')
           Foreman::Deprecation.api_deprecation_warning(
             format(
               '/api/v2/%{controller} API endpoints are deprecated, please use /foreman_puppet/api/v2/%{controller} instead',


### PR DESCRIPTION
Remove deprecation warning:
2021-09-10T09:06:47 [I|app|cefaa0e7] Started POST "/api/smart_proxies/1/import_puppetclasses" for ... at 2021-09-10 09:06:47 +0000
2021-09-10T09:06:47 [I|app|cefaa0e7] Processing by ForemanPuppet::Api::V2::EnvironmentsController#import_puppetclasses as JSON
2021-09-10T09:06:47 [I|app|cefaa0e7]   Parameters: {"dryrun"=>false, "apiv"=>"v2", "id"=>"1", "environment"=>{}}
2021-09-10T09:06:47 [I|app|cefaa0e7] Authorized user admin(Admin User)
2021-09-10T09:06:47 [W|api|cefaa0e7] /api/v2/environments API endpoints are deprecated, please use /foreman_puppet/api/v2/environments instead
