### PR TITLE
Fix core route error

### DIFF
--- a/app/helpers/foreman_puppet/puppet_smart_proxies_helper.rb
+++ b/app/helpers/foreman_puppet/puppet_smart_proxies_helper.rb
@@ -4,5 +4,9 @@ module ForemanPuppet
     def hosts_path(*attrs)
       main_app.hosts_path(*attrs)
     end
+
+    def host_config_reports_path(*attrs)
+      main_app.host_config_reports_path(*attrs)
+    end
   end
 end


### PR DESCRIPTION
We are rendering core templates which uses core routes, but we are rendering them in plugin scope.
This means the route helpers are not being found.

Fixes #187