### PR TITLE
Force the insert on migration

### DIFF
--- a/db/migrate/20200803113803_migrate_environment_to_puppet_facet.foreman_puppet.rb
+++ b/db/migrate/20200803113803_migrate_environment_to_puppet_facet.foreman_puppet.rb
@@ -2,11 +2,11 @@ class MigrateEnvironmentToPuppetFacet < ActiveRecord::Migration[6.0]
   def up
     puppet_hostgroups = ::Hostgroup.unscoped.where.not(environment_id: nil).pluck(:id, :environment_id)
     puppet_hostgroups.map! { |hg_id, env_id| { hostgroup_id: hg_id, environment_id: env_id } }
-    ForemanPuppet::HostgroupPuppetFacet.insert_all(puppet_hostgroups) if puppet_hostgroups.any?
+    ForemanPuppet::HostgroupPuppetFacet.insert_all!(puppet_hostgroups) if puppet_hostgroups.any?
 
     puppet_hosts = Host::Managed.unscoped.where.not(environment_id: nil).pluck(:id, :environment_id)
     puppet_hosts.map! { |host_id, env_id| { host_id: host_id, environment_id: env_id } }
-    ForemanPuppet::HostPuppetFacet.insert_all(puppet_hosts) if puppet_hosts.any?
+    ForemanPuppet::HostPuppetFacet.insert_all!(puppet_hosts) if puppet_hosts.any?
   end
 
   def down


### PR DESCRIPTION
If we do not force inserts, Rails tries to skip duplicates, which is not supported on some environments.
This makes the migration flaky and fail on badly configured environmets for no reason.

Fixes #191