### PR TITLE
Added missing Puppet CA trait

### DIFF
--- a/test/factories/host_puppet_enhancements.rb
+++ b/test/factories/host_puppet_enhancements.rb
@@ -45,6 +45,9 @@ FactoryBot.modify do
       puppet_proxy do
         FactoryBot.create(:smart_proxy, features: [FactoryBot.create(:feature, :puppet)])
       end
+      puppet_ca_proxy do
+        FactoryBot.create(:smart_proxy, features: [FactoryBot.create(:feature, :puppetca)])
+      end
     end
 
     trait :with_config_group do


### PR DESCRIPTION
Previously, there was a trait named `with_puppet_orchestration` that had both puppet and puppetca proxies associated. Now there is no such trait, this adds it.

Would it be possible to backport this into plugin version for Foreman 3.0 so I could use it in many of discovery tests for 3.0 branch?