### PR TITLE
Drop direct references for Puppetclasses

### DIFF
--- a/app/controllers/foreman_puppet/api/v2/hostgroup_classes_controller.rb
+++ b/app/controllers/foreman_puppet/api/v2/hostgroup_classes_controller.rb
@@ -20,7 +20,7 @@ module ForemanPuppet
 
         def create
           @hostgroup_class = HostgroupClass.create!(hostgroup_puppet_facet_id: @hostgroup.puppet.id, puppetclass_id: params[:puppetclass_id].to_i)
-          render json: { hostgroup_id: @hostgroup_class.hostgroup_id, puppetclass_id: @hostgroup_class.puppetclass_id }
+          render json: { hostgroup_id: @hostgroup.puppet.hostgroup_id, puppetclass_id: @hostgroup_class.puppetclass_id }
         end
 
         api :DELETE, '/hostgroups/:hostgroup_id/puppetclass_ids/:id/', N_('Remove a Puppet class from host group')

--- a/db/migrate/20201125113903_migrate_puppetclasses_to_facets.foreman_puppet.rb
+++ b/db/migrate/20201125113903_migrate_puppetclasses_to_facets.foreman_puppet.rb
@@ -33,17 +33,9 @@ class MigratePuppetclassesToFacets < ActiveRecord::Migration[6.0]
       hostgroup_facet ||= ForemanPuppet::HostgroupPuppetFacet.create(hostgroup: Hostgroup.unscoped.find(hostgroup_id))
       ForemanPuppet::HostgroupClass.where(hostgroup_id: hostgroup_id).update_all(hostgroup_puppet_facet_id: hostgroup_facet.id)
     end
-
-    change_column_null(:host_classes, :host_id, true)
-    change_column_null(:hostgroup_classes, :hostgroup_id, true)
-    # remove_reference(:host_classes, :host, index: true, foreign_key: true)
-    # remove_reference(:hostgroup_classes, :hostgroup, index: true, foreign_key: true)
   end
 
   def down
-    # add_reference :host_classes, :host, foreign_key: true, index: true
-    # add_reference :hostgroup_classes, :hostgroup, foreign_key: true, index: true
-
     host_facets_ids = ForemanPuppet::HostClass.joins(:host_puppet_facet).pluck(:host_puppet_facet_id, 'host_puppet_facets.host_id')
     host_facets_ids.each do |host_facet_id, host_id|
       ForemanPuppet::HostClass.where(host_puppet_facet_id: host_facet_id).update_all(host_id: host_id)

--- a/db/migrate/20211111125003_drop_puppetclasses_direct_references.foreman_puppet.rb
+++ b/db/migrate/20211111125003_drop_puppetclasses_direct_references.foreman_puppet.rb
@@ -1,0 +1,11 @@
+class DropPuppetclassesDirectReferences < ActiveRecord::Migration[6.0]
+  def up
+    remove_reference(:host_classes, :host, index: true, foreign_key: true)
+    remove_reference(:hostgroup_classes, :hostgroup, index: true, foreign_key: true)
+  end
+
+  def down
+    add_reference :host_classes, :host, foreign_key: true, index: true
+    add_reference :hostgroup_classes, :hostgroup, foreign_key: true, index: true
+  end
+end


### PR DESCRIPTION
We are using references through Facets in the plugin, but the old references to Host and Hostgroup were still in place.
We were preventing deletes for users who migrated as those columns were never cleaned up.
We needed these during the migration as old code relied on thos, but now we can safely remove them.