### PR TITLE
Cleanup environment columns from core tables

### DIFF
--- a/db/migrate/20211112130803_cleanup_environment_from_core_tables.foreman_puppet.rb
+++ b/db/migrate/20211112130803_cleanup_environment_from_core_tables.foreman_puppet.rb
@@ -1,0 +1,10 @@
+class CleanupEnvironmentFromCoreTables < ActiveRecord::Migration[6.0]
+  def up
+    ::Hostgroup.update_all(environment_id: nil) if column_exists?(:hostgroups, :environment_id)
+    Host::Managed.update_all(environment_id: nil) if column_exists?(:hosts, :environment_id)
+  end
+
+  def down
+    # nothing to do
+  end
+end


### PR DESCRIPTION
We have left the core tables to include the information.
This fixes it for new plugin installs.