### PR TITLE
EnsureNotUsedBy has no namespace anymore

### DIFF
--- a/app/models/concerns/foreman_puppet/extensions/provisioning_template.rb
+++ b/app/models/concerns/foreman_puppet/extensions/provisioning_template.rb
@@ -5,7 +5,7 @@ module ForemanPuppet
 
       included do
         has_many :environments, through: :template_combinations
-        before_destroy ActiveRecord::Base::EnsureNotUsedBy.new(:environments)
+        before_destroy EnsureNotUsedBy.new(:environments)
 
         scoped_search relation: :environments, on: :name, rename: :environment, complete_value: true
 


### PR DESCRIPTION
Remove the namespace after https://github.com/theforeman/foreman/pull/8946 has pulled it out of it.

Fixes #231