### PR TITLE
Upgrade compatibility matrix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ You can install it on Foreman 2.5 to prepare for the Foreman update.
 
 |Foreman version|Plugin version|Notes                                     |
 |---------------|--------------|------------------------------------------|
-| >= 3.0        | ~> 1.0       | Required                                 |
+| >= 3.2        | ~> 3.0       | Required                                 |
+| ~> 3.1        | ~> 2.0       | Required                                 |
+| ~> 3.0        | ~> 1.0       | Required                                 |
 | >= 2.5        | ~> 0.1       | Optional; replaces Core features         |
 | < 2.5         | -            | Not supported (functionality is in Core) |
 


### PR DESCRIPTION
I have seen multiple people on discourse who have the wrong Foreman/plugin combinations. Do we need to adjust packaging or something like that as well? Or Foreman dependency in our gemspec?