### PR TITLE
Remove lookup as a PUPPETMASTER_ACTION

### DIFF
--- a/app/controllers/concerns/foreman_puppet/extensions/hosts_controller_extensions.rb
+++ b/app/controllers/concerns/foreman_puppet/extensions/hosts_controller_extensions.rb
@@ -3,7 +3,7 @@ module ForemanPuppet
     module HostsControllerExtensions
       extend ActiveSupport::Concern
 
-      PUPPETMASTER_ACTIONS = %i[externalNodes lookup].freeze
+      PUPPETMASTER_ACTIONS = %i[externalNodes].freeze
       PUPPET_AJAX_REQUESTS = %w[hostgroup_or_environment_selected puppetclass_parameters].freeze
 
       MULTIPLE_EDIT_ACTIONS = %w[select_multiple_environment update_multiple_environment


### PR DESCRIPTION
In [Foreman's 0265427b9cb814dabf371099351a9ba5af837c3b](https://github.com/theforeman/foreman/commit/0265427b9cb814dabf371099351a9ba5af837c3b) this has been added and has since been moved over to various places. It appears to have been a mistake and nobody noticed all these years. It even survived moving to another repository.

I considered dropping the constant too and inlining it, but this is a smaller patch that's easier to review.