### PR TITLE
Do not create table under old name

### DIFF
--- a/db/migrate_foreman/20090905150132_create_hostgroups_puppetclasses.foreman_puppet.rb
+++ b/db/migrate_foreman/20090905150132_create_hostgroups_puppetclasses.foreman_puppet.rb
@@ -1,6 +1,8 @@
 class CreateHostgroupsPuppetclasses < ActiveRecord::Migration[6.0]
   def up
-    create_table :hostgroups_puppetclasses, id: false, if_not_exists: true do |t|
+    # this table is later renamed into hostgroup_classes and thus we don't want to create it if it exists under the later name
+    return if table_exists?(:hostgroups_puppetclasses) || table_exists?(:hostgroup_classes)
+    create_table :hostgroups_puppetclasses, id: false do |t|
       t.references :hostgroup, foreign_key: true, null: false
       t.references :puppetclass, foreign_key: true, null: false
     end


### PR DESCRIPTION
The migration from foreman is creating the hostgroups table under its old name
This causes the check for its existence to pass, even though it exists.

Fixes #246