### PR TITLE
Add forgotten permitted action for edit_classes

### DIFF
--- a/db/migrate/20220201205305_migrate_host_class_permission.foreman_puppet.rb
+++ b/db/migrate/20220201205305_migrate_host_class_permission.foreman_puppet.rb
@@ -1,0 +1,9 @@
+class MigrateHostClassPermission < ActiveRecord::Migration[6.0]
+  def up
+    Permission.where(resource_type: 'HostClass').update_all(resource_type: 'ForemanPuppet::HostClass')
+  end
+
+  def down
+    # no can do
+  end
+end

--- a/lib/foreman_puppet/register.rb
+++ b/lib/foreman_puppet/register.rb
@@ -147,7 +147,8 @@ Foreman::Plugin.register :foreman_puppet do
     permission :import_puppetclasses, { 'foreman_puppet/puppetclasses' => %i[import_environments obsolete_and_new],
                                         'foreman_puppet/api/v2/environments' => [:import_puppetclasses] },
       resource_type: 'ForemanPuppet::Puppetclass'
-    permission :edit_classes, { 'foreman_puppet/api/v2/host_classes': %i[index create destroy] },
+    permission :edit_classes, { :host_editing => [:edit_classes],
+                                'foreman_puppet/api/v2/host_classes' => %i[index create destroy] },
       resource_type: 'ForemanPuppet::HostClass'
   end
 


### PR DESCRIPTION
We have removed the action from edit_classes permission,
but even tho the controller does not exists, we are checking for permissions on it.

This adds the permitted action of host_editing/edit_classes to edit_classes permission.

Fixes #244