### PR TITLE
Test empting classes

### DIFF
--- a/test/controllers/foreman_puppet/api/v2/hosts_controller_test.rb
+++ b/test/controllers/foreman_puppet/api/v2/hosts_controller_test.rb
@@ -79,11 +79,21 @@ module ForemanPuppet
 
           test 'should update with puppet class' do
             puppetclass = environment.puppetclasses.first
+            # uses the deprecated version of params passing without namespace, to test it works :)
             put :update, params: { id: host.id, host: { environment_id: environment.id, puppetclass_ids: [puppetclass.id] } }
             assert_response :success
             response = JSON.parse(@response.body)
             assert_equal environment.id, response['environment_id'], "Can't update host with environment #{environment}"
             assert_equal puppetclass.id, response['puppetclasses'][0]['id'], "Can't update host with puppetclass #{puppetclass}"
+          end
+
+          test 'should remove puppetclass by passing empty array' do
+            host2 = FactoryBot.create(:host, :with_puppet_enc, :with_puppetclass)
+
+            put :update, params: { id: host2.id, host: { puppet_attributes: { puppetclass_ids: [] } } }
+            assert_response :success
+            response = JSON.parse(@response.body)
+            assert_empty(response['puppetclasses'], 'Can not remove puppetclasses')
           end
         end
 

--- a/test/models/foreman_puppet/host_puppet_facet_test.rb
+++ b/test/models/foreman_puppet/host_puppet_facet_test.rb
@@ -53,6 +53,17 @@ module ForemanPuppet
       end
     end
 
+    describe '#puppetclass_ids=' do
+      test 'allows empting classes' do
+        host = FactoryBot.create(:host, :with_puppet_enc,
+          environment: environment,
+          puppetclasses: [puppetclass_both])
+        host.attributes = { puppet_attributes: { puppetclass_ids: [] } }
+        assert host.save, 'Host could not be saved after updating puppetclasses'
+        assert_empty host.reload.all_puppetclasses, 'Puppetclasses were not removed successfuly'
+      end
+    end
+
     describe '#all_puppetclasses' do
       test 'should return all classes for environment only' do
         host = FactoryBot.create(:host, :with_puppet_enc,


### PR DESCRIPTION
This did not work due to a foreman issue, that wrongly defines the facet associations.

Fixes #253

Needs https://github.com/theforeman/foreman/pull/9083 to work