### PR TITLE
Migrate ignore_types from taxonomies

### DIFF
--- a/db/migrate/20220208135305_migrate_environment_ignore_type.foreman_puppet.rb
+++ b/db/migrate/20220208135305_migrate_environment_ignore_type.foreman_puppet.rb
@@ -1,0 +1,15 @@
+class MigrateEnvironmentIgnoreType < ActiveRecord::Migration[6.0]
+  def up
+    taxonomies = Taxonomy.unscoped.where("ignore_types LIKE '%Environment%'")
+    environment_ids = ForemanPuppet::Environment.unscoped.pluck(:id)
+
+    taxonomies.each do |tax|
+      new_types = tax.ignore_types.reject { |type| type == 'Environment' }
+      tax.update_columns(ignore_types: new_types)
+      taxable_rows = environment_ids.map do |env_id|
+        { taxable_id: env_id, taxable_type: 'ForemanPuppet::Environment', taxonomy_id: tax.id }
+      end
+      TaxableTaxonomy.insert_all(taxable_rows) if taxable_rows.any?
+    end
+  end
+end


### PR DESCRIPTION
In core we could use Environment in ignore_types.
This is not possible in a plugin and thus we just migrate it to the Taxonomy to include all the existing environments.

Fixes #255