### PR TITLE
Correctly show help buttons

### DIFF
--- a/app/helpers/foreman_puppet/environments_helper.rb
+++ b/app/helpers/foreman_puppet/environments_helper.rb
@@ -11,7 +11,7 @@ module ForemanPuppet
     def environments_title_actions
       title_actions import_proxy_select(hash_for_import_environments_environments_path.merge(engine: foreman_puppet)),
         button_group(new_link(_('Create Puppet Environment'), { engine: foreman_puppet }, id: 'new_environment')),
-        button_group(help_button)
+        button_group(link_to(_('Help'), { action: 'welcome' }, { class: 'btn btn-default' }))
     end
   end
 end

--- a/app/views/foreman_puppet/config_groups/index.html.erb
+++ b/app/views/foreman_puppet/config_groups/index.html.erb
@@ -2,7 +2,9 @@
 <% content_for(:search_bar) { } %>
 <% title _('Config Groups') %>
 
-<% title_actions new_link(_('Create Config Group'), { engine: foreman_puppet }, id: 'new_config_group'), help_button %>
+<% title_actions(
+     new_link(_('Create Config Group'), { engine: foreman_puppet }, id: 'new_config_group'),
+     link_to(_('Help'), { action: 'welcome' }, { class: 'btn btn-default' })) %>
 
 <table class="<%= table_css_classes 'table-fixed' %>">
   <thead>


### PR DESCRIPTION
Core helper is designed to work only for core controllers.
The easiest way to fix the buttons is to not use the helper as it does very little.