### PR TITLE
Removes hack for Site manager role

### DIFF
--- a/lib/foreman_puppet/register.rb
+++ b/lib/foreman_puppet/register.rb
@@ -153,7 +153,6 @@ Foreman::Plugin.register :foreman_puppet do
   end
 
   add_all_permissions_to_default_roles
-  Foreman::Plugin::RbacSupport::AUTO_EXTENDED_ROLES |= ['Site manager']
   add_permissions_to_default_roles(
     'Site manager' => %w[view_puppetclasses import_puppetclasses view_environments import_environments
                          view_external_parameters create_external_parameters edit_external_parameters destroy_external_parameters]


### PR DESCRIPTION
We've introduced a hack for Site manager role to be able to add perms to it.
In https://projects.theforeman.org/issues/34351 we have implemented the proper solution tho.
Since that we do not need this workaround.