### PR TITLE
[CP 3.0] Fixes #34909 - register helper to ComputeResourcesVmsController

### DIFF
--- a/lib/foreman_puppet/engine.rb
+++ b/lib/foreman_puppet/engine.rb
@@ -58,6 +58,7 @@ module ForemanPuppet
       ::Api::V2::TemplateCombinationsController.include ForemanPuppet::Extensions::ApiTemplateCombinationsController
       ::Api::V2::HostsController.include ForemanPuppet::Extensions::ParametersHost
       ::Api::V2::HostgroupsController.include ForemanPuppet::Extensions::ParametersHostgroup
+      ::ComputeResourcesVmsController.helper ForemanPuppet::HostsAndHostgroupsHelper
       ::OperatingsystemsController.prepend ForemanPuppet::Extensions::OperatingsystemsController
       ::HostsController.include ForemanPuppet::Extensions::HostsControllerExtensions
       ::HostsController.include ForemanPuppet::Extensions::ParametersHost


### PR DESCRIPTION
the `compute_resources_vms/import.html.erb` in Foreman is counting on the
presence of the `host_puppet_environment_field` helper from
`ForemanPuppet::HostsAndHostgroupsHelper`

(cherry picked from commit ad4d2b29a7f36f679c34d8c9c9e2b6c9f46c4e2c)