### PR TITLE
Fix the taxable_taxonomies creation

### DIFF
--- a/db/migrate/20220208135305_migrate_environment_ignore_type.foreman_puppet.rb
+++ b/db/migrate/20220208135305_migrate_environment_ignore_type.foreman_puppet.rb
@@ -7,7 +7,8 @@ class MigrateEnvironmentIgnoreType < ActiveRecord::Migration[6.0]
       new_types = tax.ignore_types.reject { |type| type == 'Environment' }
       tax.update_columns(ignore_types: new_types)
       taxable_rows = environment_ids.map do |env_id|
-        { taxable_id: env_id, taxable_type: 'ForemanPuppet::Environment', taxonomy_id: tax.id }
+        data = { taxable_id: env_id, taxable_type: 'ForemanPuppet::Environment', taxonomy_id: tax.id }
+        TaxableTaxonomy.column_names.include?('created_at') ? data.merge({ created_at: Time.zone.now, updated_at: Time.zone.now }) : data
       end
       TaxableTaxonomy.insert_all(taxable_rows) if taxable_rows.any?
     end


### PR DESCRIPTION
When the migration creates the records in taxable_taxonomies, it does
not set any value to created_at and updated_at magic columns. It uses
`insert_all` which skips callbacks, so they remain null. There are
databases which enforces the column not to be null, therefore we need to
be setting the values manually.