### PR TITLE
GraphQL: Fix host initialization

### DIFF
--- a/app/graphgl/concerns/foreman_puppet/mutations/hosts/create_extensions.rb
+++ b/app/graphgl/concerns/foreman_puppet/mutations/hosts/create_extensions.rb
@@ -4,16 +4,20 @@ module ForemanPuppet
   module Mutations
     module Hosts
       module CreateExtensions
-        PUPPET_PARAMS = %i[
-          environment
-          puppetclasses
-        ].freeze
-
         extend ActiveSupport::Concern
 
         included do
+          prepend PatchMethods
+
           argument :environment_id, GraphQL::Types::ID, loads: ForemanPuppet::Types::Environment
           argument :puppetclass_ids, [GraphQL::Types::ID], loads: ForemanPuppet::Types::Puppetclass, as: :puppetclasses
+        end
+
+        module PatchMethods
+          PUPPET_PARAMS = %i[
+            environment
+            puppetclasses
+          ].freeze
 
           private
 

--- a/test/graphql/mutations/hosts/create_mutation_test.rb
+++ b/test/graphql/mutations/hosts/create_mutation_test.rb
@@ -6,7 +6,18 @@ module ForemanPuppet
       class CreateMutationTest < GraphQLQueryTestCase
         let(:hostname) { 'my-graphql-host' }
         let(:tax_location) { FactoryBot.create(:location) }
+        let(:location_id) { Foreman::GlobalId.for(tax_location) }
         let(:organization) { FactoryBot.create(:organization) }
+        let(:organization_id) { Foreman::GlobalId.for(organization) }
+        let(:domain) { FactoryBot.create(:domain) }
+        let(:domain_id) { Foreman::GlobalId.for(domain) }
+        let(:operatingsystem) { FactoryBot.create(:operatingsystem, :with_grub, :with_associations) }
+        let(:operatingsystem_id) { Foreman::GlobalId.for(operatingsystem) }
+        let(:ptable_id) { Foreman::GlobalId.for(operatingsystem.ptables.first) }
+        let(:medium_id) { Foreman::GlobalId.for(operatingsystem.media.first) }
+        let(:architecture_id) { Foreman::GlobalId.for(operatingsystem.architectures.first) }
+        let(:ip) { '192.0.2.1' }
+
         let(:environment) { FactoryBot.create(:environment, locations: [tax_location], organizations: [organization]) }
         let(:environment_id) { Foreman::GlobalId.for(environment) }
         let(:puppetclass) { FactoryBot.create(:puppetclass) }
@@ -16,6 +27,14 @@ module ForemanPuppet
           {
             name: hostname,
             environmentId: environment_id,
+            ip: ip,
+            locationId: location_id,
+            organizationId: organization_id,
+            domainId: domain_id,
+            operatingsystemId: operatingsystem_id,
+            ptableId: ptable_id,
+            mediumId: medium_id,
+            architectureId: architecture_id,
             puppetclassIds: [puppetclass_id],
             interfacesAttributes: [
               {
@@ -37,12 +56,29 @@ module ForemanPuppet
             mutation createHostMutation(
                 $name: String!,
                 $environmentId: ID,
+                $ip: String,
+                $locationId: ID!,
+                $organizationId: ID!,
+                $domainId: ID,
+                $operatingsystemId: ID,
+                $architectureId: ID,
+                $ptableId: ID,
+                $mediumId: ID,
                 $puppetclassIds: [ID!],
                 $interfacesAttributes: [InterfaceAttributesInput!]
               ) {
               createHost(input: {
                 name: $name,
                 environmentId: $environmentId,
+                ip: $ip,
+                architectureId: $architectureId,
+                locationId: $locationId,
+                organizationId: $organizationId,
+                domainId: $domainId,
+                operatingsystemId: $operatingsystemId,
+                architectureId: $architectureId,
+                ptableId: $ptableId,
+                mediumId: $mediumId,
                 puppetclassIds: $puppetclassIds,
                 interfacesAttributes: $interfacesAttributes,
               }) {
@@ -77,6 +113,8 @@ module ForemanPuppet
             assert interface.primary
             assert interface.provision
             assert interface.managed
+
+            assert_not_nil host.pxe_loader
 
             assert_not_nil data
           end


### PR DESCRIPTION
`#initialize_object` needs to be prepended to initialize host correctly because`super` calls `Mutations::CreateMutation#initialize_object` instead of `Mutations::Hosts::Create#initialize_object`.

https://github.com/theforeman/foreman_puppet/blob/a98f8dd2a196d43162dc75c5b05dbe7c59a9a73a/app/graphgl/concerns/foreman_puppet/mutations/hosts/create_extensions.rb#L20-L24