### PR TITLE
Fixes host details puppet tab crashing on enter

### DIFF
--- a/webpack/src/Extends/Host/PuppetTab/SubTabs/Reports/components/DescriptionCard.js
+++ b/webpack/src/Extends/Host/PuppetTab/SubTabs/Reports/components/DescriptionCard.js
@@ -1,7 +1,11 @@
 import PropTypes from 'prop-types';
-import React from 'react';
-import CardTemplate from 'foremanReact/components/HostDetails/Templates/CardItem/CardTemplate';
+import React, { useState } from 'react';
 import {
+  Card,
+  CardTitle,
+  CardHeader,
+  CardBody,
+  CardExpandableContent,
   DescriptionList,
   DescriptionListTerm,
   DescriptionListGroup,
@@ -19,53 +23,73 @@ const DescriptionCard = ({
   caProxyId,
   env,
   status,
-}) => (
-  <CardTemplate header={__('Puppet details')} expandable>
-    <DescriptionList isCompact>
-      <DescriptionListGroup>
-        <DescriptionListTerm>{__('Puppet environment')}</DescriptionListTerm>
-        <DescriptionListDescription>
-          <SkeletonLoader
-            emptyState={<DefaultLoaderEmptyState />}
-            status={status}
-          >
-            {env && (
-              <a href={`/foreman_puppet/environments/?search=name+%3D+${env}`}>
-                {env}
-              </a>
-            )}
-          </SkeletonLoader>
-        </DescriptionListDescription>
-      </DescriptionListGroup>
-      <DescriptionListGroup>
-        <DescriptionListTerm>{__('Puppet Smart Proxy')}</DescriptionListTerm>
-        <DescriptionListDescription>
-          <SkeletonLoader
-            emptyState={<DefaultLoaderEmptyState />}
-            status={status}
-          >
-            {proxyName && (
-              <a href={`/smart_proxies/${proxyId}#puppet`}>{proxyName}</a>
-            )}
-          </SkeletonLoader>
-        </DescriptionListDescription>
-      </DescriptionListGroup>
-      <DescriptionListGroup>
-        <DescriptionListTerm>{__('Puppet CA Smart Proxy')}</DescriptionListTerm>
-        <DescriptionListDescription>
-          <SkeletonLoader
-            emptyState={<DefaultLoaderEmptyState />}
-            status={status}
-          >
-            {caProxy && (
-              <a href={`/smart_proxies/${caProxyId}#puppet-ca`}>{caProxy}</a>
-            )}
-          </SkeletonLoader>
-        </DescriptionListDescription>
-      </DescriptionListGroup>
-    </DescriptionList>
-  </CardTemplate>
-);
+}) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  return (
+    <Card isExpanded={isExpanded}>
+      <CardHeader onExpand={() => setIsExpanded(e => !e)} isToggleRightAligned>
+        <CardTitle>{__('Puppet details')}</CardTitle>
+      </CardHeader>
+      <CardExpandableContent>
+        <CardBody>
+          <DescriptionList isCompact>
+            <DescriptionListGroup>
+              <DescriptionListTerm>
+                {__('Puppet environment')}
+              </DescriptionListTerm>
+              <DescriptionListDescription>
+                <SkeletonLoader
+                  emptyState={<DefaultLoaderEmptyState />}
+                  status={status}
+                >
+                  {env && (
+                    <a
+                      href={`/foreman_puppet/environments/?search=name+%3D+${env}`}
+                    >
+                      {env}
+                    </a>
+                  )}
+                </SkeletonLoader>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+            <DescriptionListGroup>
+              <DescriptionListTerm>
+                {__('Puppet Smart Proxy')}
+              </DescriptionListTerm>
+              <DescriptionListDescription>
+                <SkeletonLoader
+                  emptyState={<DefaultLoaderEmptyState />}
+                  status={status}
+                >
+                  {proxyName && (
+                    <a href={`/smart_proxies/${proxyId}#puppet`}>{proxyName}</a>
+                  )}
+                </SkeletonLoader>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+            <DescriptionListGroup>
+              <DescriptionListTerm>
+                {__('Puppet CA Smart Proxy')}
+              </DescriptionListTerm>
+              <DescriptionListDescription>
+                <SkeletonLoader
+                  emptyState={<DefaultLoaderEmptyState />}
+                  status={status}
+                >
+                  {caProxy && (
+                    <a href={`/smart_proxies/${caProxyId}#puppet-ca`}>
+                      {caProxy}
+                    </a>
+                  )}
+                </SkeletonLoader>
+              </DescriptionListDescription>
+            </DescriptionListGroup>
+          </DescriptionList>
+        </CardBody>
+      </CardExpandableContent>
+    </Card>
+  );
+};
 
 DescriptionCard.propTypes = {
   caProxy: PropTypes.string,


### PR DESCRIPTION
No need to use `cardTemplate` as it used more for tabs with a lot of cards that need container logic and remembering if cards are expended or not.
