### PR TITLE
Remove the tabs that were not yet implemented

### DIFF
--- a/lib/foreman_puppet/register.rb
+++ b/lib/foreman_puppet/register.rb
@@ -1,5 +1,5 @@
 Foreman::Plugin.register :foreman_puppet do
-  requires_foreman '>= 3.4.0'
+  requires_foreman '>= 3.5.0'
   # Add Global JS file for extending foreman-core components and routes
   register_global_js_file 'global'
 

--- a/lib/foreman_puppet/version.rb
+++ b/lib/foreman_puppet/version.rb
@@ -1,3 +1,3 @@
 module ForemanPuppet
-  VERSION = '4.0.3'.freeze
+  VERSION = '5.0.0'.freeze
 end

--- a/webpack/src/Extends/Host/PuppetTab/Routes.js
+++ b/webpack/src/Extends/Host/PuppetTab/Routes.js
@@ -1,9 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Route, Switch, Redirect } from 'react-router-dom';
-import { translate as __ } from 'foremanReact/common/I18n';
 import { route } from './helpers';
-import EmptyPage from './SubTabs/EmptyPage';
 import Reports from './SubTabs/Reports';
 import ENCPreview from './SubTabs/ENCPreview';
 
@@ -12,7 +10,7 @@ const SecondaryTabRoutes = ({ hostName, hostInfo, status }) => (
     <Route path={route('reports')}>
       <Reports hostName={hostName} hostInfo={hostInfo} status={status} />
     </Route>
-    <Route path={route('assigned')}>
+    {/* <Route path={route('assigned')}>
       <EmptyPage
         header={__('Assigned classes')}
         description={__('This tab is still a work in progress')}
@@ -23,7 +21,7 @@ const SecondaryTabRoutes = ({ hostName, hostInfo, status }) => (
         header={__('Smart class parameters')}
         description={__('This tab is still a work in progress')}
       />
-    </Route>
+    </Route> */}
     <Route path={route('yaml')}>
       <ENCPreview hostName={hostName} />
     </Route>

--- a/webpack/src/Extends/Host/PuppetTab/SubTabs/ENCPreview/index.js
+++ b/webpack/src/Extends/Host/PuppetTab/SubTabs/ENCPreview/index.js
@@ -36,7 +36,7 @@ const ENCPreview = ({ hostName }) => {
   }
   if (response !== '' || response !== undefined) {
     return (
-      <div className="enc-preview-tab" padding="16px 24px">
+      <div className="enc-preview-tab" style={{ padding: '16px 24px' }}>
         <ENCTab encData={response} />
       </div>
     );

--- a/webpack/src/Extends/Host/PuppetTab/constants.js
+++ b/webpack/src/Extends/Host/PuppetTab/constants.js
@@ -2,7 +2,9 @@ import { translate as __ } from 'foremanReact/common/I18n';
 
 export const SECONDARY_TABS = [
   { key: 'reports', title: __('Reports') },
-  { key: 'assigned', title: __('Assigned classes') },
-  { key: 'smart-classes', title: __('Smart class parameters') },
+  /** Hiding the two tabs since they were not implemented yet and shouldn't be part of the release.
+   * { key: 'assigned', title: __('Assigned classes') },
+   * { key: 'smart-classes', title: __('Smart class parameters') },
+   */
   { key: 'yaml', title: __('ENC Preview') },
 ];


### PR DESCRIPTION
- [Remove the tabs that were not yet implemented](https://github.com/theforeman/foreman_puppet/commit/63ed436d7047ff69998974376973f061a1399906) 
hiding the assigned and smart-classes sub tabs,
since they were not yet implemented

- [Bump foreman_puppet to 5.0.0](https://github.com/theforeman/foreman_puppet/commit/5961bfb4364f9e2d4cfdb32680e791aa4e0dd92d) 
https://github.com/theforeman/foreman_puppet/commit/0335faaf13b721f69d126508ebc5686726bdb6b6 is using a new functionality which requires a new foreman version,
this should bump our plugin's major version to 5.0.0