### PR TITLE
Fixes #35822 - Renaming header of selectable column

### DIFF
--- a/lib/foreman_puppet/register.rb
+++ b/lib/foreman_puppet/register.rb
@@ -227,7 +227,7 @@ Foreman::Plugin.register :foreman_puppet do
   end
   extend_page 'hosts/_list' do |context|
     context.with_profile :puppet, _('Puppet'), default: true do
-      add_pagelet :hosts_table_column_header, key: :environment, label: s_('Environment name'), sortable: true, width: '10%', class: 'hidden-xs'
+      add_pagelet :hosts_table_column_header, key: :environment, label: s_('Puppet env'), sortable: true, width: '10%', class: 'hidden-xs'
       add_pagelet :hosts_table_column_content, key: :environment, callback: ->(host) { host.environment }, class: 'hidden-xs ellipsis'
     end
   end


### PR DESCRIPTION
Changing header name from `Environment name` to `Puppet env`.