### PR TITLE
Remove unused rspec-rails dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,5 +19,4 @@ end
 
 gemspec
 
-gem 'rspec-rails', '~> 4.0.1', groups: %i[development test]
 gem 'theforeman-rubocop', '~> 0.1.1', groups: %i[development rubocop]

--- a/Rakefile
+++ b/Rakefile
@@ -14,8 +14,6 @@ load 'rails/tasks/engine.rake'
 Bundler::GemHelper.install_tasks
 
 require 'rake/testtask'
-require 'rspec/core'
-require 'rspec/core/rake_task'
 
 Rake::TestTask.new(test: 'app:db:test:prepare') do |t|
   t.libs << 'test'
@@ -24,8 +22,5 @@ Rake::TestTask.new(test: 'app:db:test:prepare') do |t|
   t.pattern = 'test/**/*_test.rb'
   t.verbose = false
 end
-
-desc 'Run all specs in spec directory (excluding plugin specs)'
-RSpec::Core::RakeTask.new(spec: 'app:db:test:prepare')
 
 task default: :test


### PR DESCRIPTION
The rspec tests were dropped, so the dependency can also be dropped.

Fixes: 958841594157ec52e5d8c3abc40bbefdad3ef953