### PR TITLE
open up @theforeman dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,17 +21,17 @@
     "url": "http://projects.theforeman.org/projects/foreman_puppet/issues"
   },
   "peerDependencies": {
-    "@theforeman/vendor": "^10.1.0"
+    "@theforeman/vendor": ">= 10.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.7.0",
     "@sheerun/mutationobserver-shim": "^0.3.3",
-    "@theforeman/builder": "^10.1.0",
-    "@theforeman/eslint-plugin-foreman": "^10.1.0",
-    "@theforeman/find-foreman": "^10.1.0",
-    "@theforeman/stories": "^10.1.0",
-    "@theforeman/test": "^10.1.0",
-    "@theforeman/vendor-dev": "^10.1.0",
+    "@theforeman/builder": ">= 10.1.0",
+    "@theforeman/eslint-plugin-foreman": ">= 10.1.0",
+    "@theforeman/find-foreman": ">= 10.1.0",
+    "@theforeman/stories": ">= 10.1.0",
+    "@theforeman/test": ">= 10.1.0",
+    "@theforeman/vendor-dev": ">= 10.1.0",
     "babel-eslint": "^10.0.3",
     "eslint": "^6.7.2",
     "jed": "^1.1.1",


### PR DESCRIPTION
this makes packaging easier by dropping the upper bound on the dependencies

See also
- https://github.com/theforeman/foreman_rh_cloud/commit/65660aaa793d8c64d331095d7b825db06bfd6d3b
- https://github.com/theforeman/foreman_discovery/commit/c83a075bd382e4f818b3beb80da4a59716b2cf00
- https://github.com/theforeman/foreman_bootdisk/commit/c05a5ecfc377154cebdeef0c959764c9d0d93631