### PR TITLE
Fixes #36421 - do not load non-existant charts.js

### DIFF
--- a/app/views/smart_proxies/plugins/_puppet.html.erb
+++ b/app/views/smart_proxies/plugins/_puppet.html.erb
@@ -1,4 +1,3 @@
-<% javascript 'charts' %>
 <ul id="proxy-puppet-tab" class="nav nav-tabs nav-tabs-pf">
   <li class="active"><a href="#puppet_dashboard" data-toggle="tab"><%= _('General')%></a></li>
   <li><a href="#puppet_envs" data-toggle="tab"><%= _('Environments') %></a></li>
@@ -16,7 +15,7 @@
         </div>
       </div>
     </div>
-    <div class="clearfix row container-cards-pf container-fluid" data-ajax-url="<%= foreman_puppet.dashboard_puppet_smart_proxy_path(@smart_proxy) %>" data-on-complete="refreshCharts"><%= spinner %></div>
+    <div class="clearfix row container-cards-pf container-fluid" data-ajax-url="<%= foreman_puppet.dashboard_puppet_smart_proxy_path(@smart_proxy) %>"><%= spinner %></div>
   </div>
   <div class="tab-pane" id="puppet_envs" data-ajax-url="<%= foreman_puppet.environments_puppet_smart_proxy_path(@smart_proxy) %>">
     <%= spinner %>


### PR DESCRIPTION
We used charts.js from Foreman, but that was dropped in Foreman 3.0 (https://github.com/theforeman/foreman/commit/69379b51a33344de93836950565ecbfae0c4df23) and results in 404 errors when trying to load the smart proxy details page.