### PR TITLE
Refs #36274 - fix 'Import Puppet Environment' breadcrumb text

### DIFF
--- a/app/views/foreman_puppet/common/_puppetclasses_or_envs_changed.html.erb
+++ b/app/views/foreman_puppet/common/_puppetclasses_or_envs_changed.html.erb
@@ -1,4 +1,9 @@
 <% title _("Changed environments") %>
+<%= breadcrumbs(switchable: false,
+                items: [
+                  { caption: _('Puppet Environments'), url: environments_path },
+                  { caption: _('Changed environments') }
+                ]) %>
 <%= form_tag controller.send("obsolete_and_new_#{controller_name}_path") do %>
   <h4><%= _("Select the changes you want to apply to Foreman") %></h4>
   <h6>

--- a/app/views/foreman_puppet/environments/welcome.html.erb
+++ b/app/views/foreman_puppet/environments/welcome.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:title, _("Puppet environments")) %>
-<%= breadcrumbs(:switchable => false,
-                :items => [
-                  { :caption => _('Puppet Environments'), :url => environments_path },
+<%= breadcrumbs(switchable: false,
+                items: [
+                  { caption: _('Puppet Environments'), url: environments_path },
                   { caption: @page_header }
                 ]) %>
 


### PR DESCRIPTION
breadcrumb text in puppet environment is still set incorrectly as `Lifecycle Environments`

