### PR TITLE
Fix tests for Ruby 3.0

### DIFF
--- a/.github/workflows/ruby_tests.yml
+++ b/.github/workflows/ruby_tests.yml
@@ -15,16 +15,10 @@ jobs:
     uses: theforeman/actions/.github/workflows/rubocop.yml@v0
     with:
       command: bundle exec rubocop -P --format github
-      
+
   test:
     name: Ruby
     needs: rubocop
-    runs-on: ubuntu-latest
-
-    env:
-      BUNDLE_FOREMAN: '0'
-
-    steps:
-    - uses: theforeman/actions/.github/workflows/foreman_plugin.yml@v0
-      with:
-        plugin: foreman_puppet
+    uses: theforeman/actions/.github/workflows/foreman_plugin.yml@v0
+    with:
+      plugin: foreman_puppet

--- a/test/models/foreman_puppet/host_test.rb
+++ b/test/models/foreman_puppet/host_test.rb
@@ -172,7 +172,7 @@ module ForemanPuppet
         host.expects(:template_kinds).returns(template_kinds)
         template_kinds.each do |kind|
           ::ProvisioningTemplate.expects(:find_template)
-                                .with(kind: kind.name, operatingsystem_id: host.operatingsystem.id, hostgroup_id: host.hostgroup.id, environment_id: host.puppet.environment.id)
+                                .with({ kind: kind.name, operatingsystem_id: host.operatingsystem.id, hostgroup_id: host.hostgroup.id, environment_id: host.puppet.environment.id })
                                 .returns(stub(name: "default #{kind.name}"))
         end
         assert_equal template_kinds.map { |k| "default #{k.name}" }, host.available_template_kinds.map(&:name)
@@ -183,7 +183,7 @@ module ForemanPuppet
         host.expects(:template_kinds).returns(template_kinds)
         template_kinds.each do |kind|
           ::ProvisioningTemplate.expects(:find_template)
-                                .with(kind: kind.name, operatingsystem_id: host.operatingsystem.id, hostgroup_id: host.hostgroup.id, environment_id: nil)
+                                .with({ kind: kind.name, operatingsystem_id: host.operatingsystem.id, hostgroup_id: host.hostgroup.id, environment_id: nil })
                                 .returns(stub(name: "default #{kind.name}"))
         end
         assert_equal template_kinds.map { |k| "default #{k.name}" }, host.available_template_kinds.map(&:name)


### PR DESCRIPTION
~Please, don't merge just yet. Foreman on Ruby 3.0 is still in progress.~

Depends on https://github.com/theforeman/foreman_puppet/pull/381 ~. Included here.~