### PR TITLE
Fix querying for hosts using puppet class

### DIFF
--- a/app/models/concerns/foreman_puppet/extensions/host.rb
+++ b/app/models/concerns/foreman_puppet/extensions/host.rb
@@ -24,10 +24,9 @@ module ForemanPuppet
           conditions = sanitize_sql_for_conditions(["puppetclasses.name #{operator} ?", value_to_sql(operator, value)])
           config_group_ids = ForemanPuppet::ConfigGroup.joins(:puppetclasses).where(conditions).pluck(:id)
           host_ids         = ::Host.authorized(:view_hosts).joins(puppet: :puppetclasses).where(conditions).distinct.pluck(:id)
-          host_ids        += ForemanPuppet::HostConfigGroup
-                             .where(host_type: 'ForemanPuppet::HostPuppetFacet')
-                             .where(config_group_id: config_group_ids)
-                             .pluck(:host_id)
+          host_ids        += ForemanPuppet::HostPuppetFacet.joins(:host_config_groups)
+                                                           .where(host_config_groups: { config_group_id: config_group_ids })
+                                                           .pluck(:host_id)
           hostgroup_ids = ::Hostgroup.unscoped.with_taxonomy_scope.joins(puppet: :puppetclasses).where(conditions).map(&:subtree_ids)
           if config_group_ids.any?
             hostgroup_cg_ids = ForemanPuppet::HostgroupPuppetFacet.joins(:host_config_groups)


### PR DESCRIPTION
When trying to query foreman for hosts that are using a particular puppet class, the query does not return the desired results.  In the process of tracking this down we also encountered #386 / #387 .

----

Given the puppet class, it correctly lists that there are two hosts using that class.
<img width="400" alt="Screenshot 2024-03-30 at 22 32 08" src="https://github.com/theforeman/foreman_puppet/assets/19505408/3a06c690-4d67-4249-8313-f9615960d15b">

If we follow the link we are presented with the following hosts using the class
<img width="400" alt="Screenshot 2024-03-30 at 22 32 38" src="https://github.com/theforeman/foreman_puppet/assets/19505408/d15e882b-554a-43dd-8ec6-efc5ac322c52">

This was tracked down to a missing sql join.  We got there by raising errors and doing some explains.  The queries below were ran directly to help us debug.

```
foreman=# SELECT "config_groups"."id" FROM "config_groups" INNER JOIN "config_group_classes" ON "config_group_classes"."config_group_id" = "config_groups"."id" INNER JOIN "puppetclasses" ON "puppetclasses"."id" = "config_group_classes"."puppetclass_id" WHERE (puppetclasses.name = 'profiles::lanes::protected') ORDER BY config_groups.name;
 id 
----
 10
(1 row)


foreman=# SELECT "host_config_groups"."host_id" FROM "host_config_groups" WHERE "host_config_groups"."host_type" = 'ForemanPuppet::HostPuppetFacet' AND "host_config_groups"."config_group_id" = 10;
 host_id 
---------
     270
     183
(2 rows)
```
The above host_ids are actually host facet ids so the it tries to query these as host ids resulting in the mismatch.
Adding the below sql before running the query for hosts we get to what we expect
```
foreman=# select * from host_puppet_facets where id = 270 or id = 183;
 id  | host_id | environment_id | puppet_proxy_id | created_at |         updated_at         
-----+---------+----------------+-----------------+------------+----------------------------
 270 |     430 |              1 |                 |            | 
 183 |     460 |              1 |                 |            | 2022-07-03 18:29:34.534469
(2 rows)

foreman=# select id, name from hosts where id = 430 or id = 460;
 id  |                    name                    
-----+--------------------------------------------
 460 | trust-0002.dev.***
 430 | trust-0001.dev.***
(2 rows)
```

Using the changed code that is in the PR, and performing the same query we get the desired results
<img width="400" alt="Screenshot 2024-03-31 at 21 40 05" src="https://github.com/theforeman/foreman_puppet/assets/19505408/c2aac0e9-5a52-4b1f-8fc1-b49ec0f37655">
