### PR TITLE
Add customizable column to React HostsIndex page

### DIFF
--- a/webpack/global_index.js
+++ b/webpack/global_index.js
@@ -1,4 +1,6 @@
 import { registerReducer } from 'foremanReact/common/MountingService';
+import { registerColumns } from 'foremanReact/components/HostsIndex/Columns/core';
+import { translate as __ } from 'foremanReact/common/I18n';
 import reducers from './src/reducers';
 import { registerFills } from './src/Extends/Fills';
 import { registerLegacy } from './legacy';
@@ -9,3 +11,22 @@ registerReducer('puppet', reducers);
 registerFills();
 // TODO: the checkForUnavailablePuppetclasses is very nasty
 registerLegacy();
+
+// register columns for React hosts index page
+const puppetHostsIndexColumns = [
+  {
+    columnName: 'environment',
+    title: __('Puppet env'),
+    isSorted: true,
+    wrapper: hostDetails => hostDetails.environment_name,
+    weight: 2700,
+  },
+];
+
+puppetHostsIndexColumns.forEach(column => {
+  column.tableName = 'hosts';
+  column.categoryName = 'Puppet';
+  column.categoryKey = 'puppet';
+});
+
+registerColumns(puppetHostsIndexColumns);


### PR DESCRIPTION
Add a "Puppet env" column to the new React All Hosts page.

For a demo with some more context, see https://www.youtube.com/watch?v=bzZEOiJOrCg&t=1808s

This will bring "column parity" for foreman_puppet between the legacy and new All Hosts page.
