### PR TITLE
Fixes #37652 - change jquery size to length

### DIFF
--- a/webpack/src/foreman_puppet_host_form.js
+++ b/webpack/src/foreman_puppet_host_form.js
@@ -110,7 +110,7 @@ export function checkForUnavailablePuppetclasses() {
       ${warningMessage}
     </span>`;
 
-  if (unavailableClasses.size() > 0) {
+  if (unavailableClasses.length > 0) {
     if (puppetEncTab.find('#puppetclasses_unavailable_warning').length <= 0) {
       tab.prepend('<span class="pficon pficon-warning-triangle-o"></span> ');
       puppetEncTab.prepend(warning);

--- a/webpack/src/foreman_puppet_host_form.test.js
+++ b/webpack/src/foreman_puppet_host_form.test.js
@@ -37,7 +37,7 @@ describe('checkForUnavailablePuppetclasses', () => {
     );
 
     checkForUnavailablePuppetclasses();
-    expect($('#puppetclasses_unavailable_warning').size()).toBe(1);
+    expect($('#puppetclasses_unavailable_warning').length).toBe(1);
   });
 
   it('does not add a warning if no unavailable classes are found', () => {
@@ -48,8 +48,7 @@ describe('checkForUnavailablePuppetclasses', () => {
     expect(
       $('#hostgroup .help-block')
         .first()
-        .children()
-        .size()
+        .children().length
     ).toBe(0);
   });
 
@@ -59,7 +58,7 @@ describe('checkForUnavailablePuppetclasses', () => {
     );
     checkForUnavailablePuppetclasses();
     setTimeout(() => {
-      expect($('a .pficon').size()).toBe(1);
+      expect($('a .pficon').length).toBe(1);
     }, 100);
   });
 });


### PR DESCRIPTION
Tested that the warning still appears:
Have 2 puppet envs
Create a host with env1 and class1 from it
Edit host to have env2, the warning appears 

.size is deprecated and length can be used instead