### PR TITLE
Fix environment param in smart proxies controller

### DIFF
--- a/app/controllers/concerns/foreman_puppet/extensions/api_smart_proxies_controller.rb
+++ b/app/controllers/concerns/foreman_puppet/extensions/api_smart_proxies_controller.rb
@@ -140,7 +140,7 @@ module ForemanPuppet
       end
 
       def find_optional_environment
-        @environment = Environment.authorized(:view_environments).find(@env_id) if @env_id
+        @environment = resource_finder(Environment.authorized(:view_environments), @env_id) if @env_id
       rescue ActiveRecord::RecordNotFound => e
         Foreman::Logging.exception('Resource not found', e, level: :debug)
         nil


### PR DESCRIPTION
Hello!

We noticed an issue in the way environments parameter is used in the proxies controller:
routes `/api/environments/:environment/` handles environment name as `:environment` param, while `/api/environments/:environment/smart_proxies/:smart_proxy_id/import_puppetclasses` searches for a numerical identifier.

This leads to _all_ the environments being imported when a name is specified.

To stay consistent, the fix uses the same method as the one used on `/api/environments/:environment/` to find the environment.