### PR TITLE
Zeitwerk & ProvisioningTemplate extensions

### DIFF
--- a/app/models/concerns/foreman_puppet/extensions/provisioning_template.rb
+++ b/app/models/concerns/foreman_puppet/extensions/provisioning_template.rb
@@ -6,6 +6,7 @@ module ForemanPuppet
       included do
         has_many :environments, through: :template_combinations
         before_destroy EnsureNotUsedBy.new(:environments)
+        before_save :remove_snippet_associations
 
         scoped_search relation: :environments, on: :name, rename: :environment, complete_value: true
 
@@ -54,9 +55,9 @@ module ForemanPuppet
         end
 
         # check if our template is a snippet, and remove its associations just in case they were selected.
-        def check_for_snippet_assoications
-          super
+        def remove_snippet_associations
           return unless snippet
+
           environments.clear
         end
       end

--- a/test/models/foreman_puppet/provisioning_template_test.rb
+++ b/test/models/foreman_puppet/provisioning_template_test.rb
@@ -20,7 +20,7 @@ module ForemanPuppet
       assert_equal [environment], tmplt.environments
     end
 
-    test 'should not save assoications if snippet' do
+    test 'should not save associations if snippet' do
       tmplt          = ProvisioningTemplate.new
       tmplt.name     = 'Default Kickstart'
       tmplt.template = 'Some kickstart goes here'


### PR DESCRIPTION
Removing Puppet's associations from snippets
stopped working with the latest changes
in Zeitwerk and the way we load the classes.